### PR TITLE
Fix null object key value in payload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,10 @@ internals.sanitize = (obj) => {
 
     const keys = Object.keys(obj);
     for (let i = 0; i < keys.length; ++i) {
+        if (obj[keys[i]] === null) {
+            continue;
+        }
+        
         if (typeof obj[keys[i]] === 'object') {
             if (Array.isArray(obj[keys[i]])) {
                 obj[keys[i]].forEach(internals.recurseObj);


### PR DESCRIPTION
When trying to UNSET a database relation when using HAPI, we can send PATCH payloads with NULL values.

Exemple:
```json
{
    "id": 5,
    "name": "Ok test", 
    "parentId": 2
}
```

To unset the parentId using PATCH method, i need to be able to send 
```json
{
    "parentId": null
}
```

to the `/myItem/5` endpoint.

Value is then a null value, considered as an Object by Javascript, which result in as TypeError in the library, Object.keys can't work on NULL, which give a `Cannot convert undefined or null to object at Function.keys` error.

We can't use the `deleteEmpty` option because we want the full payload to Unset values in database.